### PR TITLE
Typo on default environment

### DIFF
--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -18,6 +18,8 @@ if (!defined('ABSPATH')) {
  * Version: 2.0.4
  * Author: Transbank
  * Author URI: https://www.transbank.cl
+ * WC requires at least: 3.4.0
+ * WC tested up to: 3.5.4
  */
 
 add_action('plugins_loaded', 'woocommerce_transbank_init', 0);

--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -62,7 +62,7 @@ function woocommerce_transbank_init() {
             $webpay_webpay_cert = (new TransbankSdkWebpay(null))->getWebPayCertDefault();
 
             $this->config = array(
-                "MODO" => trim($this->get_option('webpay_test_mode', 'INTEGRATION')),
+                "MODO" => trim($this->get_option('webpay_test_mode', 'INTEGRACION')),
                 "COMMERCE_CODE" => trim($this->get_option('webpay_commerce_code', $webpay_commerce_code)),
                 "PRIVATE_KEY" => trim(str_replace("<br/>", "\n", $this->get_option('webpay_private_key', $webpay_private_key))),
                 "PUBLIC_CERT" => trim(str_replace("<br/>", "\n", $this->get_option('webpay_public_cert', $webpay_public_cert))),


### PR DESCRIPTION
By default, the default environment is `Integracion`. But there is a typo in the plugin, referencing to Ìntegration` instead of `Integracion`, causing an error when trying to start a transaction.

This PR fix that.

Also, I've added metadata to tell to Woocommerce that the plugin is supported by the last version of WC.