### PR TITLE
Marcar orden como "procesando" tras pagarse

### DIFF
--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -222,7 +222,7 @@ function woocommerce_transbank_init() {
 
                     $order_info->add_order_note(__('Pago exitoso con Webpay Plus', 'woocommerce'));
                     $order_info->add_order_note(__(json_encode($result), 'woocommerce'));
-                    $order_info->update_status('completed');
+                    $order_info->update_status('processing');
                     $order_info->reduce_order_stock();
                     self::redirect($result->urlRedirection, array("token_ws" => $token_ws));
                     die();


### PR DESCRIPTION
Los plugins de woocommerce de transbank siempre han convertido las ordenes pagadas en ordenes "completadas", contradiciendo la lógica de funcionamiento de woocomerce el cual por defecto considera una orden pagada como "procesando". Entiendo que dependiendo de la tienda una u otra forma puede ser mas útil, pero considero que el plugin por defecto debiese seguir el estándar de los demás métodos de pago.