### PR TITLE
Chore/unify transaction result information

### DIFF
--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -839,14 +839,27 @@ function woocommerce_transbank_init() {
         $paymenCodeResult = $transbank_data->config['VENTA_DESC'][$paymentTypeCode];
 
         if ($finalResponse->detailOutput->responseCode == 0) {
-            $transactionResponse = "Aceptado";
+            $transactionResponse = "Transacci&oacute;n Aprobada";
         } else {
-            $transactionResponse = "Rechazado [" . $finalResponse->detailOutput->responseCode . "]";
+            $transactionResponse = "Transacci&oacute;n Rechazada [" . $finalResponse->detailOutput->responseCode . "]";
         }
 
         $date_accepted = new DateTime($finalResponse->transactionDate);
 
         if ($finalResponse != null) {
+
+            if($paymentTypeCode == "SI" || $paymentTypeCode == "S2" ||
+                $paymentTypeCode == "NC" || $paymentTypeCode == "VC" ) {
+                $installmentType = $paymenCodeResult;
+            } else {
+                $installmentType = "Sin cuotas";
+            }
+
+            if($paymentTypeCode == "VD"){
+                $paymentType = "Débito";
+            } else {
+                $paymentType = "Crédito";
+            }
 
             update_post_meta($order_id, 'transactionResponse', $transactionResponse);
             update_post_meta($order_id, 'buyOrder', $finalResponse->buyOrder);
@@ -863,6 +876,12 @@ function woocommerce_transbank_init() {
                     '<th scope="row">Respuesta de la Transacci&oacute;n:</th>' .
                     '<td><span class="RT">' .
                     $transactionResponse .
+                    '</span></td>' .
+                    '</tr>' .
+                    '<tr>' .
+                    '<th scope="row">C&oacute;digo de la Transacci&oacute;n:</th>' .
+                    '<td><span class="CT">' .
+                    $finalResponse->detailOutput->responseCode .
                     '</span></td>' .
                     '</tr>' .
                     '<tr>' .
@@ -898,7 +917,14 @@ function woocommerce_transbank_init() {
                     '<tr>' .
                     '<th scope="row">Tipo de Pago:</th>' .
                     '<td><span class="TP">' .
-                    $paymenCodeResult .
+                    $paymentType .
+                    '</span></td>' .
+                    '</tr>' .
+                    '<tr>' .
+                    '<tr>' .
+                    '<th scope="row">Tipo de Cuota:</th>' .
+                    '<td><span class="TC">' .
+                    $installmentType .
                     '</span></td>' .
                     '</tr>' .
                     '<tr>' .

--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -841,7 +841,7 @@ function woocommerce_transbank_init() {
         if ($finalResponse->detailOutput->responseCode == 0) {
             $transactionResponse = "Transacci&oacute;n Aprobada";
         } else {
-            $transactionResponse = "Transacci&oacute;n Rechazada [" . $finalResponse->detailOutput->responseCode . "]";
+            $transactionResponse = "Transacci&oacute;n Rechazada";
         }
 
         $date_accepted = new DateTime($finalResponse->transactionDate);

--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -921,7 +921,6 @@ function woocommerce_transbank_init() {
                     '</span></td>' .
                     '</tr>' .
                     '<tr>' .
-                    '<tr>' .
                     '<th scope="row">Tipo de Cuota:</th>' .
                     '<td><span class="TC">' .
                     $installmentType .


### PR DESCRIPTION
Across all plugins the information being shown wasn't the same.

Now the information shown in the transaction success information screen is the same for all plugins.

Disclaimer: The order of the information shown might not be the same