### PR TITLE
Fix change of status from completed to failed

### DIFF
--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -226,9 +226,11 @@ function woocommerce_transbank_init() {
             }
 
             $order_info = new WC_Order($order_id);
-            $order_info->add_order_note(__('Pago rechazado con Webpay Plus', 'woocommerce'));
-            $order_info->add_order_note(__(json_encode($result), 'woocommerce'));
-            $order_info->update_status('failed');
+            if ($$order_info->get_status() == 'pending') {
+                $order_info->add_order_note(__('Pago rechazado con Webpay Plus', 'woocommerce'));
+                $order_info->add_order_note(__(json_encode($result), 'woocommerce'));
+                $order_info->update_status('failed');
+            }
 
             $error_message = "Estimado cliente, le informamos que su orden termin&oacute; de forma inesperada";
             wc_add_notice(__('ERROR: ', 'woothemes') . $error_message, 'error');

--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -226,12 +226,11 @@ function woocommerce_transbank_init() {
             }
 
             $order_info = new WC_Order($order_id);
-            if ($$order_info->get_status() == 'pending') {
+            if ($order_info->has_status( 'pending')) {
                 $order_info->add_order_note(__('Pago rechazado con Webpay Plus', 'woocommerce'));
                 $order_info->add_order_note(__(json_encode($result), 'woocommerce'));
                 $order_info->update_status('failed');
             }
-
             $error_message = "Estimado cliente, le informamos que su orden termin&oacute; de forma inesperada";
             wc_add_notice(__('ERROR: ', 'woothemes') . $error_message, 'error');
 


### PR DESCRIPTION
- Prevent that the order status change to failed from other ended status. This can happen when the user pay correctly but press the back button and transbank try to process the same transaction.