### PR TITLE
Prepare release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2020-01-07
+### Added
+- Agrega métricas de uso cuando se pasa a producción en la configuración o al actualizar el plugin.
+
+
 ## [2.4.1] - 2019-11-18
 ### Fixed
 - Corrige confirmación del pago de la orden de compra, permite a los integradores asociar flujos a woocommerce_payment_complete.

--- a/package.sh
+++ b/package.sh
@@ -5,7 +5,7 @@ echo "Travis tag: $TRAVIS_TAG"
 
 if [ "$TRAVIS_TAG" = "" ]
 then
-   TRAVIS_TAG='2.4.1'
+   TRAVIS_TAG='2.4.2'
 fi
 
 SRC_DIR="woocommerce-transbank"


### PR DESCRIPTION
You can see full changes here [2.4.1...chore/prepare-release-2.5.0](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay/compare/2.4.1...chore/prepare-release-2.5.0)