### PR TITLE
Remove unused include and prevent plugin conflicts

### DIFF
--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -28,7 +28,6 @@ if (!defined('ABSPATH')) {
 
 add_action('plugins_loaded', 'woocommerce_transbank_init', 0);
 
-require_once ABSPATH . "wp-includes/pluggable.php";
 require_once plugin_dir_path(__FILE__) . "vendor/autoload.php";
 require_once plugin_dir_path(__FILE__) . "libwebpay/HealthCheck.php";
 require_once plugin_dir_path(__FILE__) . "libwebpay/LogHandler.php";


### PR DESCRIPTION
This include generates conflicts with some other plugins and it is not needed anymore. I tested all the payment flow, PDF creation and everything works as expected. 