### PR TITLE
Default order status after successful payment

### DIFF
--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -227,7 +227,7 @@ function woocommerce_transbank_init()
                         'wc-refunded' => 'Reembolsado',
                         'wc-failed' => 'Fallido'
                     ],
-                    'default' => 'wc-pending'
+                    'default' => 'wc-processing'
                 ]
             ];
         }


### PR DESCRIPTION
Resolves https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay/issues/94

wc-processing should be the default status (for payment gateways after a successful payment) according to WC's docs: https://docs.woocommerce.com/document/managing-orders/#section-1
