### PR TITLE
Show alert on wordpress panel if woocommerce is not active

### DIFF
--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -359,7 +359,10 @@ function add_action_links($links)
 function on_webpay_plugin_activation()
 {
     woocommerce_transbank_init();
-    
+    if (!class_exists(WC_Gateway_Transbank::class)) {
+        die('Se necesita tener WooCommerce instalado y activo para poder activar este plugin');
+        return;
+    }
     $pluginObject = new WC_Gateway_Transbank();
     $pluginObject->registerPluginVersion();
 }


### PR DESCRIPTION
Show alert on wordpress panel if woocommerce is not active