### PR TITLE
Refactor code and fix payment flow issues

### DIFF
--- a/woocommerce-transbank/src/Controllers/FinalProcessController.php
+++ b/woocommerce-transbank/src/Controllers/FinalProcessController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Transbank\WooCommerce\Webpay\Controllers;
+
+use DateTime;
+use Transbank\WooCommerce\Webpay\Exceptions\InvalidOrderException;
+use Transbank\WooCommerce\Webpay\Helpers\SessionMessageHelper;
+use Transbank\WooCommerce\Webpay\TransbankWebpayOrders;
+use WC_Gateway_Transbank;
+use WC_Order;
+
+/**
+ * Class ThanksPageController
+ *
+ * @package Transbank\WooCommerce\Webpay\Controllers
+ */
+class FinalProcessController
+{
+    /**
+     * @var array
+     */
+    protected $pluginConfig;
+    /**
+     * ResponseController constructor.
+     *
+     * @param array $pluginConfig
+     */
+    public function __construct(array $pluginConfig)
+    {
+        $this->pluginConfig = $pluginConfig;
+    }
+    
+    /**
+     * @throws InvalidOrderException
+     * @throws \Transbank\WooCommerce\Webpay\Exceptions\TokenNotFoundOnDatabaseException
+     */
+    public function show()
+    {
+        $webpayTransaction = $this->getWebpayTransactionByToken();
+    
+        $order_info = new WC_Order($webpayTransaction->order_id);
+        $transbank_data = new WC_Gateway_transbank();
+        if ($order_info->get_payment_method_title() != $transbank_data->title) {
+            throw new \Exception('Esta transacción no fue pagada con Webpay');
+        }
+        
+        // If we receive and order that is still initialized, it means it did not pass to the responseUrl, so this
+        // is a 'Anular' button flow or a Webpay Error link press.
+        switch ($webpayTransaction->status) {
+            case TransbankWebpayOrders::STATUS_INITIALIZED:
+            case TransbankWebpayOrders::STATUS_ABORTED_BY_USER:
+                //wc_add_notice(,
+                SessionMessageHelper::set('Compra <strong>Anulada</strong> por usuario. Recuerda que puedes volver a intentar el pago', 'error');
+                
+                $this->setOrderAsCancelledByUser($order_info, $webpayTransaction);
+                return wp_redirect($order_info->get_cancel_order_url());
+                
+            case TransbankWebpayOrders::STATUS_APPROVED:
+                return wp_redirect($order_info->get_checkout_order_received_url());
+                
+            case TransbankWebpayOrders::STATUS_FAILED:
+                wc_add_notice('Pago <strong>fallido</strong>. Su pago no ha sido efectuado, pero puede volver a intentarlo', 'error');
+                return wp_redirect($order_info->get_cancel_order_url());
+        }
+        
+        
+        
+        
+    }
+    /**
+     * @param WC_Order $order_info
+     * @param $webpayTransaction
+     */
+    protected function setOrderAsCancelledByUser(WC_Order $order_info, $webpayTransaction)
+    {
+// Transaction aborted by user
+        $order_info->add_order_note(__('Pago abortado por el usuario', 'woocommerce'));
+        $order_info->update_status('cancelled');
+        TransbankWebpayOrders::update($webpayTransaction->id,
+            ['status' => TransbankWebpayOrders::STATUS_ABORTED_BY_USER]);
+    }
+    /**
+     * @param $orderId
+     * @return mixed
+     * @throws InvalidOrderException
+     * @throws \Transbank\WooCommerce\Webpay\Exceptions\TokenNotFoundOnDatabaseException
+     */
+    protected function getWebpayTransactionByToken()
+    {
+        $token = (isset($_POST['token_ws']) ? $_POST['token_ws'] : (isset($_POST['TBK_TOKEN']) ? $_POST['TBK_TOKEN'] : (isset($_GET['token_ws']) ? $_GET['token_ws'] : null)));
+        $webpayTransaction = null;
+        if ($token !== null) {
+            $webpayTransaction = TransbankWebpayOrders::getByToken($token);
+        } elseif (isset($_POST['TBK_ORDEN_COMPRA']) && isset($_POST['TBK_ID_SESION'])) {
+            $webpayTransaction = TransbankWebpayOrders::getBySessionIdAndOrderId($_POST['TBK_ID_SESION'],
+                $_POST['TBK_ORDEN_COMPRA']);
+        } else {
+            throw new \Exception('Token not provided');
+        }
+        
+        if (!$webpayTransaction) {
+            throw new InvalidOrderException('Token inválido');
+        }
+        
+        return $webpayTransaction;
+    }
+}

--- a/woocommerce-transbank/src/Controllers/ThankYouPageController.php
+++ b/woocommerce-transbank/src/Controllers/ThankYouPageController.php
@@ -3,80 +3,31 @@
 namespace Transbank\WooCommerce\Webpay\Controllers;
 
 use DateTime;
-use Transbank\WooCommerce\Webpay\Exceptions\InvalidOrderException;
 use Transbank\WooCommerce\Webpay\TransbankWebpayOrders;
 use WC_Gateway_Transbank;
 use WC_Order;
 
-class ThanksPageController
+class ThankYouPageController
 {
-    /**
-     * @var array
-     */
-    protected $pluginConfig;
-    /**
-     * ResponseController constructor.
-     *
-     * @param array $pluginConfig
-     */
-    public function __construct(array $pluginConfig)
-    {
-        $this->pluginConfig = $pluginConfig;
-    }
-    
     public function show($orderId)
     {
         $order_info = new WC_Order($orderId);
         $transbank_data = new WC_Gateway_transbank();
         if ($order_info->get_payment_method_title() != $transbank_data->title) {
-            return;
+            throw new \Exception('Esta transacción no fue pagada con Webpay');
         }
-        $token = isset($_POST['token_ws']) ? $_POST['token_ws'] : (isset($_POST['TBK_TOKEN']) ? $_POST['TBK_TOKEN'] : isset($_GET['token_ws']) ? $_GET['token_ws'] : null);
-        $webpayTransaction = null;
-        if ($token !== null) {
-            $webpayTransaction = TransbankWebpayOrders::getByToken($token);
-        } elseif (isset($_POST['TBK_ORDEN_COMPRA']) && isset($_POST['TBK_ID_SESION'])) {
-            $webpayTransaction = TransbankWebpayOrders::getBySessionIdAndOrderId($_POST['TBK_ID_SESION'], $_POST['TBK_ORDEN_COMPRA']);
-        } else {
-            throw new \Exception('Token not provided');
-        }
-        
-        
-        if (!$webpayTransaction) {
-            throw new InvalidOrderException('Token inválido');
-        }
-        if ((int)$webpayTransaction->order_id !== (int)$orderId) {
-            throw new InvalidOrderException('La orden recibida no coincide con el token');
-        }
-        
-        if ($webpayTransaction->status === TransbankWebpayOrders::STATUS_ABORTED_BY_USER) {
-            wc_print_notice('Compra <strong>Anulada</strong> por usuario. Recuerda que puedes pagar volver a intentar el pago',
-                'error');
-            
-            return;
-        }
-        
-        if (isset($_POST['TBK_TOKEN'])) {
-            $order_info = new WC_Order($orderId);
-            // Transaction aborted by user
-            $order_info->add_order_note(__('Pago abortado por el usuario', 'woocommerce'));
-            $order_info->update_status('failed');
-            wc_print_notice('Compra <strong>Anulada</strong> por usuario. Recuerda que puedes pagar volver a intentar el pago',
-                'error');
-            TransbankWebpayOrders::update($webpayTransaction->id,
-                ['status' => TransbankWebpayOrders::STATUS_ABORTED_BY_USER]);
-            
-            return wp_redirect($order_info->get_checkout_payment_url());
-        }
-        
-        if ($webpayTransaction->status == TransbankWebpayOrders::STATUS_FAILED) {
+    
+        $webpayTransaction = TransbankWebpayOrders::getApprovedByOrderId($orderId);
+        if ($webpayTransaction === null) {
             wc_print_notice('Transacción <strong>fallida</strong>. Puedes pagar volver a intentar el pago', 'error');
-        } elseif ($webpayTransaction->status == TransbankWebpayOrders::STATUS_APPROVED) {
-            wc_print_notice('Transacción aprobada', 'success');
+            return;
         }
+        
+        // Transacción aprobada
+        wc_print_notice('Transacción aprobada', 'success');
         
         $finalResponse = json_decode($webpayTransaction->transbank_response);
-        
+    
         if (isset($finalResponse->detailOutput)) {
             $detailOutput = $finalResponse->detailOutput;
             $paymentTypeCode = isset($detailOutput->paymentTypeCode) ? $detailOutput->paymentTypeCode : null;
@@ -85,39 +36,38 @@ class ThanksPageController
             $paymentTypeCode = null;
             $responseCode = null;
         }
-        
+    
         if (isset($transbank_data->config)) {
-            $paymenCodeResult = "Sin cuotas";
+            $paymentCodeResult = "Sin cuotas";
             if (array_key_exists('VENTA_DESC', $transbank_data->config)) {
                 if (array_key_exists($paymentTypeCode, $transbank_data->config['VENTA_DESC'])) {
-                    $paymenCodeResult = $transbank_data->config['VENTA_DESC'][$paymentTypeCode];
+                    $paymentCodeResult = $transbank_data->config['VENTA_DESC'][$paymentTypeCode];
                 }
             }
         }
-        
+    
         if ($responseCode == 0) {
             $transactionResponse = "Transacci&oacute;n Aprobada";
         } else {
             $transactionResponse = "Transacci&oacute;n Rechazada";
         }
-        
+    
         $transactionDate = isset($finalResponse->transactionDate) ? $finalResponse->transactionDate : null;
         $date_accepted = new DateTime($transactionDate);
+        if ($webpayTransaction->status == TransbankWebpayOrders::STATUS_APPROVED) {
         
-        if ($finalResponse != null) {
-            
             if ($paymentTypeCode == "SI" || $paymentTypeCode == "S2" || $paymentTypeCode == "NC" || $paymentTypeCode == "VC") {
-                $installmentType = $paymenCodeResult;
+                $installmentType = $paymentCodeResult;
             } else {
                 $installmentType = "Sin cuotas";
             }
-            
+        
             if ($paymentTypeCode == "VD") {
                 $paymentType = "Débito";
             } else {
                 $paymentType = "Crédito";
             }
-            
+        
             echo '</br><h2>Detalles del pago</h2>' . '<table class="shop_table order_details">' . '<tfoot>' . '<tr>' . '<th scope="row">Respuesta de la Transacci&oacute;n:</th>' . '<td><span class="RT">' . $transactionResponse . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">C&oacute;digo de la Transacci&oacute;n:</th>' . '<td><span class="CT">' . $finalResponse->detailOutput->responseCode . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">Orden de Compra:</th>' . '<td><span class="RT">' . $finalResponse->buyOrder . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">Codigo de Autorizaci&oacute;n:</th>' . '<td><span class="CA">' . $finalResponse->detailOutput->authorizationCode . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">Fecha Transacci&oacute;n:</th>' . '<td><span class="FC">' . $date_accepted->format('d-m-Y') . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row"> Hora Transacci&oacute;n:</th>' . '<td><span class="FT">' . $date_accepted->format('H:i:s') . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">Tarjeta de Cr&eacute;dito:</th>' . '<td><span class="TC">************' . $finalResponse->cardDetail->cardNumber . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">Tipo de Pago:</th>' . '<td><span class="TP">' . $paymentType . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">Tipo de Cuota:</th>' . '<td><span class="TC">' . $installmentType . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">Monto Compra:</th>' . '<td><span class="amount">' . $finalResponse->detailOutput->amount . '</span></td>' . '</tr>' . '<tr>' . '<th scope="row">N&uacute;mero de Cuotas:</th>' . '<td><span class="NC">' . $finalResponse->detailOutput->sharesNumber . '</span></td>' . '</tr>' . '</tfoot>' . '</table><br/>';
         }
     }

--- a/woocommerce-transbank/src/Helpers/SessionMessageHelper.php
+++ b/woocommerce-transbank/src/Helpers/SessionMessageHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Transbank\WooCommerce\Webpay\Helpers;
+
+class SessionMessageHelper
+{
+    const TBK_MESSAGE_SESSION_KEY='tbk_message';
+    const TBK_MESSAGE_TYPE_SESSION_KEY='tbk_message_type';
+    
+    public static function set($message, $type = 'info')
+    {
+        $_SESSION[static::TBK_MESSAGE_SESSION_KEY] = $message;
+        $_SESSION[static::TBK_MESSAGE_TYPE_SESSION_KEY] = $type;
+    }
+    
+    public static function clear()
+    {
+        $_SESSION[static::TBK_MESSAGE_SESSION_KEY] = null;
+        $_SESSION[static::TBK_MESSAGE_TYPE_SESSION_KEY] = null;
+    }
+    
+    public static function getMessage()
+    {
+        return isset($_SESSION[static::TBK_MESSAGE_SESSION_KEY]) ? $_SESSION[static::TBK_MESSAGE_SESSION_KEY] : null;
+    }
+    
+    public static function getType()
+    {
+        return isset($_SESSION[static::TBK_MESSAGE_TYPE_SESSION_KEY]) ? $_SESSION[static::TBK_MESSAGE_TYPE_SESSION_KEY] : null;
+    }
+    
+    public static function exists()
+    {
+        return isset($_SESSION[static::TBK_MESSAGE_SESSION_KEY]) && $_SESSION[static::TBK_MESSAGE_SESSION_KEY] !== null;
+    }
+    
+    public static function print()
+    {
+        if (static::exists()) {
+            wc_print_notice(static::getMessage(), static::getType());
+            static::clear();
+        }
+    }
+}

--- a/woocommerce-transbank/src/TransbankWebpayOrders.php
+++ b/woocommerce-transbank/src/TransbankWebpayOrders.php
@@ -8,10 +8,9 @@ class TransbankWebpayOrders
 {
     const TRANSACTIONS_TABLE_NAME = 'webpay_transactions';
     
+    const STATUS_INITIALIZED = 'initialized';
     const STATUS_FAILED = 'failed';
     const STATUS_ABORTED_BY_USER = 'aborted_by_user';
-    const STATUS_INITIALIZED = 'initialized';
-    const STATUS_REJECTED = 'rejected';
     const STATUS_APPROVED = 'approved';
     
     const TABLE_VERSION_OPTION_KEY = 'webpay_orders_table_version';
@@ -43,6 +42,16 @@ class TransbankWebpayOrders
         $webpayTransaction = $sqlResult[0];
     
         return $webpayTransaction;
+    }
+    
+    public static function getApprovedByOrderId($orderId)
+    {
+        global $wpdb;
+        $transaction = static::getWebpayTransactionsTableName();
+        $statusApproved = static::STATUS_APPROVED;
+        $sql = $wpdb->prepare("SELECT * FROM $transaction WHERE status = '$statusApproved' AND order_id = '%s'",  $orderId);
+        $sqlResult = $wpdb->get_results($sql);
+        return isset($sqlResult[0]) ? $sqlResult[0] : null;
     }
     
     public static function getBySessionIdAndOrderId($TBK_ID_SESION, $TBK_ORDEN_COMPRA)
@@ -99,7 +108,7 @@ class TransbankWebpayOrders
             `session_id` varchar(100),
             `status` varchar(50) NOT NULL,
             `transbank_response` LONGTEXT,
-            `updated_at` TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW(),
+            `updated_at` TIMESTAMP NOT NULL,
             `created_at` TIMESTAMP NOT NULL  DEFAULT NOW(),
             PRIMARY KEY (id)
         ) $charset_collate";


### PR DESCRIPTION
This PR fixes: 
- Cart does not get emptied when a order fails or is cancelledd by user
- When the user clicks 'Anular compra y volver' the order status is now 'cancelled' and not 'failed'
- When the user click the 'back' button before the paymennt was approved does not generate a failed order anymore. 
- In older versions of MYSQL the webpay_orders_table creation process should not fail anymore