### PR TITLE
Bug/fix paying for orders incorrect status

### DIFF
--- a/woocommerce-transbank/src/Controllers/ThankYouPageController.php
+++ b/woocommerce-transbank/src/Controllers/ThankYouPageController.php
@@ -4,6 +4,7 @@ namespace Transbank\WooCommerce\Webpay\Controllers;
 
 use DateTime;
 use Transbank\WooCommerce\Webpay\TransbankWebpayOrders;
+use Transbank\WooCommerce\Webpay\Helpers\SessionMessageHelper;
 use WC_Gateway_Transbank;
 use WC_Order;
 
@@ -19,10 +20,15 @@ class ThankYouPageController
     
         $webpayTransaction = TransbankWebpayOrders::getApprovedByOrderId($orderId);
         if ($webpayTransaction === null) {
-            wc_print_notice('Transacción <strong>fallida</strong>. Puedes pagar volver a intentar el pago', 'error');
+            // TODO: Revisar porqué no se muestra el mensaje de abajo. 
+            // if (SessionMessageHelper::exists()){
+            //     SessionMessageHelper::printMessage();
+            //     return;
+            // }
+            wc_print_notice('Transacción <strong>fallida</strong>. Puedes volver a intentar el pago', 'error');
             return;
         }
-        
+
         // Transacción aprobada
         wc_print_notice('Transacción aprobada', 'success');
         

--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -128,7 +128,7 @@ function woocommerce_transbank_init()
             
             $this->init_form_fields();
             $this->init_settings();
-    
+            
             add_action('woocommerce_thankyou', [new ThankYouPageController($this->config), 'show'], 1);
             add_action('woocommerce_api_transbankwebpaythankyoupage', [new FinalProcessController($this->config), 'show']);
             add_action('woocommerce_receipt_' . $this->id, [$this, 'receipt_page']);
@@ -227,18 +227,21 @@ function woocommerce_transbank_init()
                 ],
                 'webpay_private_key' => [
                     'title' => __('Llave Privada', 'transbank_webpay'),
+                    'description' => __('Contenido de archivo con extensión .key'),
                     'type' => 'textarea',
                     'default' => str_replace("<br/>", "\n", $this->config['PRIVATE_KEY']),
                     'css' => 'font-family: monospace'
                 ],
                 'webpay_public_cert' => [
                     'title' => __('Certificado', 'transbank_webpay'),
+                    'description' => __('Contenido de archivo con extensión .crt'),
                     'type' => 'textarea',
                     'default' => str_replace("<br/>", "\n", $this->config['PUBLIC_CERT']),
                     'css' => 'font-family: monospace'
                 ],
                 'after_payment_order_status' => [
-                    'title' => __('Estado de pedido después del pago', 'transbank_webpay'),
+                    'title' => __('Estado de pedido después del pago.'),
+                    'description' => __('<strong style="color:red;">DEPRECADO</strong>: Se eliminará en proximas versiones', 'transbank_webpay'),
                     'type' => 'select',
                     'options' => [
                         'wc-pending' => __('Pendiente', 'transbank_webpay'),


### PR DESCRIPTION
Este PR arregla el checkeo del estado de la orden antes de confirmar un pago, de esta manera no se realiza el getTransactionResult cuando no se debe y se ejecuta una reversa dependiendo de los tiempos del emisor en caso de ser un pago duplicado/erroneo