### PR TITLE
Correción ortográfica y mejora en el flujo final

### DIFF
--- a/woocommerce-transbank/src/Controllers/ResponseController.php
+++ b/woocommerce-transbank/src/Controllers/ResponseController.php
@@ -105,9 +105,7 @@ class ResponseController
         $wooCommerceOrder->add_order_note(json_encode($result, JSON_PRETTY_PRINT));
         $wooCommerceOrder->payment_complete();
         $final_status = $this->pluginConfig['STATUS_AFTER_PAYMENT'];
-        if ($final_status) {
-            $wooCommerceOrder->update_status($final_status);
-        }
+        
         list($authorizationCode, $amount, $sharesNumber, $transactionResponse, $paymentCodeResult, $date_accepted) = $this->getTransactionDetails($result);
         
         update_post_meta($wooCommerceOrder->get_id(), 'transactionResponse', $transactionResponse);
@@ -122,6 +120,10 @@ class ResponseController
         wc_add_notice(__('Pago recibido satisfactoriamente', 'transbank_webpay'));
         TransbankWebpayOrders::update($webpayTransaction->id,
             ['status' => TransbankWebpayOrders::STATUS_APPROVED, 'transbank_response' => json_encode($result)]);
+
+        if ($final_status) {
+            $wooCommerceOrder->update_status($final_status);
+        }
     }
     /**
      * @param WC_Order $wooCommerceOrder

--- a/woocommerce-transbank/src/Controllers/ResponseController.php
+++ b/woocommerce-transbank/src/Controllers/ResponseController.php
@@ -101,10 +101,6 @@ class ResponseController
      */
     protected function completeWooCommerceOrder(WC_Order $wooCommerceOrder, $result, $webpayTransaction)
     {
-        $wooCommerceOrder->add_order_note(__('Pago exitoso con Webpay Plus', 'transbank_webpay'));
-        $wooCommerceOrder->add_order_note(json_encode($result, JSON_PRETTY_PRINT));
-        $wooCommerceOrder->payment_complete();
-        $final_status = $this->pluginConfig['STATUS_AFTER_PAYMENT'];
         
         list($authorizationCode, $amount, $sharesNumber, $transactionResponse, $paymentCodeResult, $date_accepted) = $this->getTransactionDetails($result);
         
@@ -117,10 +113,15 @@ class ResponseController
         update_post_meta($wooCommerceOrder->get_id(), 'cuotas', $sharesNumber);
         update_post_meta($wooCommerceOrder->get_id(), 'transactionDate', $date_accepted->format('d-m-Y / H:i:s'));
         
+        $wooCommerceOrder->add_order_note(__('Pago exitoso con Webpay Plus', 'transbank_webpay'));
+        $wooCommerceOrder->add_order_note(json_encode($result, JSON_PRETTY_PRINT));
+        
         wc_add_notice(__('Pago recibido satisfactoriamente', 'transbank_webpay'));
         TransbankWebpayOrders::update($webpayTransaction->id,
             ['status' => TransbankWebpayOrders::STATUS_APPROVED, 'transbank_response' => json_encode($result)]);
 
+        $wooCommerceOrder->payment_complete();
+        $final_status = $this->pluginConfig['STATUS_AFTER_PAYMENT'];
         if ($final_status) {
             $wooCommerceOrder->update_status($final_status);
         }

--- a/woocommerce-transbank/webpay.php
+++ b/woocommerce-transbank/webpay.php
@@ -111,7 +111,7 @@ function woocommerce_transbank_init()
                 "URL_FINAL" => "_URL_",
                 "ECOMMERCE" => 'woocommerce',
                 "VENTA_DESC" => [
-                    "VD" => "Venta Deb&iacute;to",
+                    "VD" => "Venta D&eacute;bito",
                     "VN" => "Venta Normal",
                     "VC" => "Venta en cuotas",
                     "SI" => "3 cuotas sin inter&eacute;s",


### PR DESCRIPTION
Corregí un error ortográfico con la palabra "Débito".
Cambié el orden de ejecución de algunos comandos en el flujo de finalización de venta para que el cambio de estado de la orden woocomerce ocurra después de que se guarden los datos de la transacción que devuelve transbank